### PR TITLE
Feature/192992 disallow hide all

### DIFF
--- a/Config/BuildSettings.swift
+++ b/Config/BuildSettings.swift
@@ -219,6 +219,9 @@ final class BuildSettings: NSObject {
     static let roomSettingsScreenShowFlairSettings: Bool = true
     static let roomSettingsScreenShowAdvancedSettings: Bool = true
     
+    // MARK: - Room Participants
+    static let roomParticipantAllowHideAll : Bool = false
+    
     // MARK: - Message
     static let messageDetailsAllowShare: Bool = true
     static let messageDetailsAllowPermalink: Bool = true

--- a/LingoTests/RoomMemberDetailsViewControllerTests.swift
+++ b/LingoTests/RoomMemberDetailsViewControllerTests.swift
@@ -1,0 +1,44 @@
+// 
+// Copyright 2020 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import XCTest
+@testable import Riot
+
+class RoomMemberDetailsViewControllerTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+    
+    func test_192992_disableShowHideAllMessages() throws {
+        /// Given I am a Room Member
+        /// AND I have opened the Room
+        /// AND I have selected Room Details
+        /// AND I have selected Members
+        /// AND I have selected a Member
+        /// When the Member is displayed
+        /// Then the Hide / Show all messages from this user is not shown.
+        /// Ensure that the Hide / Show all messages from this user function has been removed entirely from the Application.
+        
+        XCTAssert(BuildSettings.roomParticipantAllowHideAll == false)
+        
+    }
+
+}

--- a/Riot.xcodeproj/project.pbxproj
+++ b/Riot.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		1411D81F252D7534009D8908 /* LingoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1411D81E252D7534009D8908 /* LingoTests.swift */; };
 		1411D835252D7597009D8908 /* RoomViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1411D834252D7597009D8908 /* RoomViewControllerTests.swift */; };
+		1411D858252D88A0009D8908 /* RoomMemberDetailsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1411D857252D88A0009D8908 /* RoomMemberDetailsViewControllerTests.swift */; };
 		24CBEC591F0EAD310093EABB /* RiotShareExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 24CBEC4E1F0EAD310093EABB /* RiotShareExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		24EEE5A21F23A8B400B3C705 /* MXRoom+Riot.m in Sources */ = {isa = PBXBuildFile; fileRef = F083BBE81E7009EC00A9B29C /* MXRoom+Riot.m */; };
 		24EEE5A31F23A8C300B3C705 /* AvatarGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = F083BC111E7009EC00A9B29C /* AvatarGenerator.m */; };
@@ -1011,6 +1012,7 @@
 		1411D81E252D7534009D8908 /* LingoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LingoTests.swift; sourceTree = "<group>"; };
 		1411D820252D7534009D8908 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		1411D834252D7597009D8908 /* RoomViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomViewControllerTests.swift; sourceTree = "<group>"; };
+		1411D857252D88A0009D8908 /* RoomMemberDetailsViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomMemberDetailsViewControllerTests.swift; sourceTree = "<group>"; };
 		1ACF09217ADF1D7E7A35BC02 /* Pods_RiotPods_Riot.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RiotPods_Riot.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		24CBEC4E1F0EAD310093EABB /* RiotShareExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = RiotShareExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		2B582BE9B2A98BCF5F740873 /* Pods-RiotPods-RiotNSE.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RiotPods-RiotNSE.debug.xcconfig"; path = "Target Support Files/Pods-RiotPods-RiotNSE/Pods-RiotPods-RiotNSE.debug.xcconfig"; sourceTree = "<group>"; };
@@ -2240,6 +2242,7 @@
 				1411D81E252D7534009D8908 /* LingoTests.swift */,
 				1411D820252D7534009D8908 /* Info.plist */,
 				1411D834252D7597009D8908 /* RoomViewControllerTests.swift */,
+				1411D857252D88A0009D8908 /* RoomMemberDetailsViewControllerTests.swift */,
 			);
 			path = LingoTests;
 			sourceTree = "<group>";
@@ -6077,6 +6080,7 @@
 			files = (
 				1411D81F252D7534009D8908 /* LingoTests.swift in Sources */,
 				1411D835252D7597009D8908 /* RoomViewControllerTests.swift in Sources */,
+				1411D858252D88A0009D8908 /* RoomMemberDetailsViewControllerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Riot/Modules/Room/Members/Detail/RoomMemberDetailsViewController.m
+++ b/Riot/Modules/Room/Members/Detail/RoomMemberDetailsViewController.m
@@ -628,7 +628,7 @@
         }
         
         // Check whether the option Ignore may be presented
-        if (self.mxRoomMember.membership == MXMembershipJoin)
+        if (self.mxRoomMember.membership == MXMembershipJoin && BuildSettings.roomParticipantAllowHideAll)
         {
             // is he already ignored ?
             if (![self.mainSession isUserIgnored:self.mxRoomMember.userId])


### PR DESCRIPTION
This PR implements the following tickets:

192992 - Disallow Hide / Show All Messages

This branch utilises the new LingoTests target introduced in PR #6 to specify unit tests for changes specific to the Lingo ACT Health project. Unit tests for 192992 are included in this PR.

The branch is based upon act-master.

This branch will build on Xcode 12 / iOS 14.


### Pull Request Checklist

* [x] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
* [x] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
-Noting there is no change currently in the display behaviour between those two settings as per requirement.
* [ ] Pull request is based on the develop branch
This branch was based upon act-master from the Pegacorn repo.
* [ ] Pull request updates [CHANGES.rst](https://github.com/vector-im/riot-ios/blob/develop/CHANGES.rst)
* [ ] Pull request includes screenshots or videos of UI changes
* [ ] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
