### PR TITLE
Feature/192990 allow remove stickers and gifs

### DIFF
--- a/Config/BuildSettings.swift
+++ b/Config/BuildSettings.swift
@@ -165,7 +165,7 @@ final class BuildSettings: NSObject {
     /// Force non-jailbroken app usage
     static let forceNonJailbrokenUsage: Bool = true
     
-    static let allowSendingStickers: Bool = true
+    static let allowSendingStickers: Bool = false //the integrations menu can be disabled from the Riot-Defaults plist, under: matrixApps
     
     static let allowLocalContactsAccess: Bool = false
     

--- a/LingoTests/RoomInputToolbarViewTests.swift
+++ b/LingoTests/RoomInputToolbarViewTests.swift
@@ -1,0 +1,41 @@
+// 
+// Copyright 2020 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import XCTest
+@testable import Riot
+
+class RoomInputToolbarViewTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+    
+    func test_192990_preventSendingStickers() throws {
+        /// Given I am a Room Member
+        /// When I select the Room
+        /// Then the following OOTB functions are removed/unavailable, including
+        ///     Send a GIF
+        ///     Send a Sticker
+        
+        XCTAssert(BuildSettings.allowSendingStickers == false) // Sending of GIFs is not enabled for iOS out of the box and does not need specific disabling
+        
+    }
+
+}

--- a/LingoTests/RoomViewControllerTests.swift
+++ b/LingoTests/RoomViewControllerTests.swift
@@ -43,6 +43,16 @@ class SettingsViewControllerTests: XCTestCase {
         XCTAssert(BuildSettings.messageDetailsAllowViewEncryptionInformation == false) // Note this is used to prevent both encryption and session information 
         
     }
+    
+    func test_192990_preventManageIntegrations() throws {
+        /// Given I am a Room Member
+        /// When I select the Room
+        /// Then the following OOTB functions are removed/unavailable, including
+        ///     Manage Integrations
+        
+        XCTAssert(UserDefaults.standard.bool(forKey: "matrixApps") == false)
+        
+    }
 
 }
 

--- a/Riot.xcodeproj/project.pbxproj
+++ b/Riot.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		1411D81F252D7534009D8908 /* LingoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1411D81E252D7534009D8908 /* LingoTests.swift */; };
 		1411D835252D7597009D8908 /* RoomViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1411D834252D7597009D8908 /* RoomViewControllerTests.swift */; };
+		1411D866252D9089009D8908 /* RoomInputToolbarViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1411D865252D9089009D8908 /* RoomInputToolbarViewTests.swift */; };
 		24CBEC591F0EAD310093EABB /* RiotShareExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 24CBEC4E1F0EAD310093EABB /* RiotShareExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		24EEE5A21F23A8B400B3C705 /* MXRoom+Riot.m in Sources */ = {isa = PBXBuildFile; fileRef = F083BBE81E7009EC00A9B29C /* MXRoom+Riot.m */; };
 		24EEE5A31F23A8C300B3C705 /* AvatarGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = F083BC111E7009EC00A9B29C /* AvatarGenerator.m */; };
@@ -1011,6 +1012,7 @@
 		1411D81E252D7534009D8908 /* LingoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LingoTests.swift; sourceTree = "<group>"; };
 		1411D820252D7534009D8908 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		1411D834252D7597009D8908 /* RoomViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomViewControllerTests.swift; sourceTree = "<group>"; };
+		1411D865252D9089009D8908 /* RoomInputToolbarViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomInputToolbarViewTests.swift; sourceTree = "<group>"; };
 		1ACF09217ADF1D7E7A35BC02 /* Pods_RiotPods_Riot.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RiotPods_Riot.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		24CBEC4E1F0EAD310093EABB /* RiotShareExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = RiotShareExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		2B582BE9B2A98BCF5F740873 /* Pods-RiotPods-RiotNSE.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RiotPods-RiotNSE.debug.xcconfig"; path = "Target Support Files/Pods-RiotPods-RiotNSE/Pods-RiotPods-RiotNSE.debug.xcconfig"; sourceTree = "<group>"; };
@@ -2240,6 +2242,7 @@
 				1411D81E252D7534009D8908 /* LingoTests.swift */,
 				1411D820252D7534009D8908 /* Info.plist */,
 				1411D834252D7597009D8908 /* RoomViewControllerTests.swift */,
+				1411D865252D9089009D8908 /* RoomInputToolbarViewTests.swift */,
 			);
 			path = LingoTests;
 			sourceTree = "<group>";
@@ -6077,6 +6080,7 @@
 			files = (
 				1411D81F252D7534009D8908 /* LingoTests.swift in Sources */,
 				1411D835252D7597009D8908 /* RoomViewControllerTests.swift in Sources */,
+				1411D866252D9089009D8908 /* RoomInputToolbarViewTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Riot/Assets/Riot-Defaults.plist
+++ b/Riot/Assets/Riot-Defaults.plist
@@ -7,7 +7,7 @@
 	<key>pinRoomsWithUnread</key>
 	<true/>
 	<key>matrixApps</key>
-	<true/>
+	<false/>
 	<key>showAllEventsInRoomHistory</key>
 	<false/>
 	<key>showRedactionsInRoomHistory</key>


### PR DESCRIPTION
This PR implements the following tickets:

192990 - Disallow Stickers, GIFs and Integrations

This branch utilises the new LingoTests target introduced in PR #6 to specify unit tests for changes specific to the Lingo ACT Health project. Unit tests for 192990 are included in this PR.

The branch is based upon act-master.

This branch will build on Xcode 12 / iOS 14.

### Pull Request Checklist

* [ ] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
* [ ] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
-Noting there is no change currently in the display behaviour between those two settings as per requirement.
* [ ] Pull request is based on the develop branch
This branch was based upon act-master from the Pegacorn repo.
* [ ] Pull request updates [CHANGES.rst](https://github.com/vector-im/riot-ios/blob/develop/CHANGES.rst)
* [ ] Pull request includes screenshots or videos of UI changes
* [ ] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
