### PR TITLE
Feature/197523 remove chat media size selector

### DIFF
--- a/Config/BuildSettings.swift
+++ b/Config/BuildSettings.swift
@@ -250,6 +250,7 @@ final class BuildSettings: NSObject {
     
     //MARK: - Room Actions
     static let roomAllowRemoveAdministrativeMessage = false
+    static let roomPromptForAttachmentSize = false
     
     //MARK: - Tab Bar Notifications Actions
     static let displayActualFavouritesNotificationCountInTabBar = true

--- a/LingoTests/RoomViewControllerTests.swift
+++ b/LingoTests/RoomViewControllerTests.swift
@@ -87,6 +87,23 @@ class RoomViewControllerTests: XCTestCase {
         XCTAssert(BuildSettings.messagesMinimumPowerLevelAllowViewRoomRightsChanges == RoomPowerLevel.user.rawValue)
         
     }
+    
+    func test_197523_preventUserOverrideOfMediaFileSizes() throws {
+        /// Given I am an authenticated user
+        /// AND I have selected my User Profile
+        /// When I select my User Settings
+        /// Then I am not able to see the Default Compression setting.
+
+        /// Given I am an authenticated user
+        /// When I am taking a photo in the Application
+        /// Then the Default Compression setting value = 'Original'.
+        
+        XCTAssert(BuildSettings.roomPromptForAttachmentSize == false)
+        
+    }
+    
+    
+    
 
 }
 

--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -5666,7 +5666,7 @@
     RoomInputToolbarView *roomInputToolbarView = [self inputToolbarViewAsRoomInputToolbarView];
     if (roomInputToolbarView)
     {
-        [roomInputToolbarView sendSelectedImage:imageData withMimeType:uti.mimeType andCompressionMode:MXKRoomInputToolbarCompressionModePrompt isPhotoLibraryAsset:NO];
+        [roomInputToolbarView sendSelectedImage:imageData withMimeType:uti.mimeType andCompressionMode:(BuildSettings.roomPromptForAttachmentSize ? MXKRoomInputToolbarCompressionModePrompt : MXKRoomInputToolbarCompressionModeNone) isPhotoLibraryAsset:NO];
     }
 }
 
@@ -5698,7 +5698,7 @@
     RoomInputToolbarView *roomInputToolbarView = [self inputToolbarViewAsRoomInputToolbarView];
     if (roomInputToolbarView)
     {
-        [roomInputToolbarView sendSelectedImage:imageData withMimeType:uti.mimeType andCompressionMode:MXKRoomInputToolbarCompressionModePrompt isPhotoLibraryAsset:YES];
+        [roomInputToolbarView sendSelectedImage:imageData withMimeType:uti.mimeType andCompressionMode:(BuildSettings.roomPromptForAttachmentSize ? MXKRoomInputToolbarCompressionModePrompt : MXKRoomInputToolbarCompressionModeNone) isPhotoLibraryAsset:YES];
     }
 }
 
@@ -5722,7 +5722,7 @@
     RoomInputToolbarView *roomInputToolbarView = [self inputToolbarViewAsRoomInputToolbarView];
     if (roomInputToolbarView)
     {
-        [roomInputToolbarView sendSelectedAssets:assets withCompressionMode:MXKRoomInputToolbarCompressionModePrompt];
+        [roomInputToolbarView sendSelectedAssets:assets withCompressionMode:(BuildSettings.roomPromptForAttachmentSize ? MXKRoomInputToolbarCompressionModePrompt : MXKRoomInputToolbarCompressionModeNone)];
     }
 }
 


### PR DESCRIPTION
This PR implements the following tickets:

197523 - Prevent user selection of file size with media attachments

This branch utilises the new LingoTests target introduced in PR #6 to specify unit tests for changes specific to the Lingo ACT Health project. Unit tests for 197523 are included in this PR.

The branch is based upon act-master.

This branch will build on Xcode 12 / iOS 14.

### Pull Request Checklist

* [x] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
* [x] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
-Noting there is no change currently in the display behaviour between those two settings as per requirement.
* [x] Pull request is based upon act-master from the Pegacorn repo.
* [x] All new and existing unit tests pass successfully in this branch.
